### PR TITLE
add some contains key PoC logic

### DIFF
--- a/jsonpath_ng/ext/filter.py
+++ b/jsonpath_ng/ext/filter.py
@@ -27,6 +27,8 @@ OPERATOR_MAP = {
     '>=': operator.ge,
     '>': operator.gt,
     '=~': lambda a, b: True if re.search(b, a) else False,
+    '~': lambda a, b: b in a,  # contains
+    '!~': lambda a, b: b not in a  # not contains
 }
 
 


### PR DESCRIPTION
Adds two different flavors of "contains key" logic, which is useful for [this](https://github.com/bridgecrewio/checkov/issues/3731) issue. 

The first approach, which actually works, uses a new operator, `~` and `!~`.

It is more intuitive as a function, but it seems like the way the library's evaluation logic is written, it needs more changes for a function to be used in a filter expression. 

This line: https://github.com/mikeurbanski1/jsonpath-ng/blob/d7bec79365478dc011730bcd41b7c6475a21b191/jsonpath_ng/ext/filter.py#L92

This method returns early if there is no "op" (specifically ==, <, >, etc). So it needs logic to recognize that this is going to return a boolean / filterable value. It would be easy enough, I just did not do it.